### PR TITLE
make afterConfirm, afterCancel callbable

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -173,7 +173,7 @@ var NavigationPrompt = function (_React$Component) {
       history[action](nextLocation.pathname);
       this.setState(_extends({}, initState, {
         unblock: this.props.history.block(this.block)
-      }), cb); // FIXME?  Does history.listen need to be used instead, for async?
+      }), (cb || function () {})()); // FIXME?  Does history.listen need to be used instead, for async?
     }
   }, {
     key: 'onCancel',
@@ -183,7 +183,7 @@ var NavigationPrompt = function (_React$Component) {
       (this.props.beforeCancel || function (cb) {
         cb();
       })(function () {
-        _this2.setState(_extends({}, initState), _this2.props.afterCancel);
+        _this2.setState(_extends({}, initState), (_this2.props.afterCancel || function () {})());
       });
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -88,14 +88,14 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
     this.setState({
       ...initState,
       unblock: this.props.history.block(this.block)
-    }, cb); // FIXME?  Does history.listen need to be used instead, for async?
+    }, (cb || (() => {}) )()); // FIXME?  Does history.listen need to be used instead, for async?
   }
 
   onCancel() {
     (this.props.beforeCancel || ((cb) => {
      cb();
     }))(() => {
-      this.setState({...initState}, this.props.afterCancel);
+      this.setState({...initState}, (this.props.afterCancel || (() => {}) )());
     });
   }
 


### PR DESCRIPTION
Hi @ZacharyRSmith I've noticed that the `afterConfirm` and `afterCancel` are not actually called in the `setState` calls. Check my PR (I've never used flow before, looks fun) 😄 