### PR TITLE
Implements prop for disabling native browser confirmation

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -145,7 +145,9 @@ var NavigationPrompt = function (_React$Component) {
   _createClass(NavigationPrompt, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      window.addEventListener('beforeunload', this.onBeforeUnload);
+      if (!this.props.disableNative) {
+        window.addEventListener('beforeunload', this.onBeforeUnload);
+      }
     }
   }, {
     key: 'componentDidUpdate',
@@ -165,7 +167,9 @@ var NavigationPrompt = function (_React$Component) {
         this.props.afterConfirm();
       }
       this.state.unblock();
-      window.removeEventListener('beforeunload', this.onBeforeUnload);
+      if (!this.props.disableNative) {
+        window.removeEventListener('beforeunload', this.onBeforeUnload);
+      }
     }
   }, {
     key: 'block',

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ declare type PropsT = {
   history: RouterHistory,
   location: Location,
   renderIfNotActive: bool,
-  when: bool | (Location, ?Location) => bool
+  when: bool | (Location, ?Location) => bool,
+  disableNative: bool,
 };
 declare type StateT = {
   action: ?HistoryAction,
@@ -66,7 +67,9 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
   }
 
   componentDidMount() {
-    window.addEventListener('beforeunload', this.onBeforeUnload);
+    if (!this.props.disableNative) {
+      window.addEventListener('beforeunload', this.onBeforeUnload);
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -84,7 +87,9 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
       this.props.afterConfirm();
     }
     this.state.unblock();
-    window.removeEventListener('beforeunload', this.onBeforeUnload);
+    if (!this.props.disableNative) {
+      window.removeEventListener('beforeunload', this.onBeforeUnload);
+    }
   }
 
   block(nextLocation, action) {


### PR DESCRIPTION
Allows for the prop `disableNative`, which prevents the NaviagtionPrompt from adding the 'beforeunload' event listener.