### PR TITLE
Fix for #2 (confirmation on browsers back button)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2018-09-26
+### Added
+- Typescript typings
+
 ## [1.6.6] - 2018-09-15
 ### Added
 - Note in README.md that BrowserHistory is supported, but not HashHistory

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ import Modal from "./your-own-code";
   - renderIfNotActive: bool,
   - when: bool | (Location, ?Location) => bool,
   - disableNative: bool,
+  - allowGoBack: bool (use _goBack_ method instead of _push_ when navigating back one or more items),
     // Added by react-router:
   - match: Match,
   - history: RouterHistory,

--- a/es/index.js
+++ b/es/index.js
@@ -132,7 +132,10 @@ var NavigationPrompt = function (_React$Component) {
     var _this = _possibleConstructorReturn(this, (NavigationPrompt.__proto__ || Object.getPrototypeOf(NavigationPrompt)).call(this, props));
 
     _this._prevUserAction = '';
-    _this._isUnmounted = true;
+
+    // This component could be used from inside a page, and therefore could be
+    // mounted/unmounted when the route changes.
+    _this._isMounted = true;
 
     _this.block = _this.block.bind(_this);
     _this.onBeforeUnload = _this.onBeforeUnload.bind(_this);
@@ -147,7 +150,6 @@ var NavigationPrompt = function (_React$Component) {
   _createClass(NavigationPrompt, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      this._isUnmounted = false;
       if (!this.props.disableNative) {
         window.addEventListener('beforeunload', this.onBeforeUnload);
       }
@@ -174,7 +176,6 @@ var NavigationPrompt = function (_React$Component) {
       if (!this.props.disableNative) {
         window.removeEventListener('beforeunload', this.onBeforeUnload);
       }
-      this._isUnmounted = true;
     }
   }, {
     key: 'block',
@@ -199,7 +200,7 @@ var NavigationPrompt = function (_React$Component) {
           nextLocation = _state.nextLocation;
 
       action = {
-        'POP': this.props.useGoBackForPop ? 'goBack' : 'push',
+        'POP': this.props.allowGoBack ? 'goBack' : 'push',
         'PUSH': 'push',
         'REPLACE': 'replace'
       }[action || 'PUSH'];

--- a/es/index.js
+++ b/es/index.js
@@ -122,7 +122,6 @@ var NavigationPrompt = function (_React$Component) {
 
   /*:: _prevUserAction: string; */
   /*:: _isMounted: bool; */
-  /*:: _isUnmounted: boolean; */
 
   function NavigationPrompt(props) {
     _classCallCheck(this, NavigationPrompt);
@@ -133,7 +132,6 @@ var NavigationPrompt = function (_React$Component) {
     var _this = _possibleConstructorReturn(this, (NavigationPrompt.__proto__ || Object.getPrototypeOf(NavigationPrompt)).call(this, props));
 
     _this._prevUserAction = '';
-    _this._isUnmounted = true;
 
     // This component could be used from inside a page, and therefore could be
     // mounted/unmounted when the route changes.
@@ -152,7 +150,6 @@ var NavigationPrompt = function (_React$Component) {
   _createClass(NavigationPrompt, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      this._isUnmounted = false;
       if (!this.props.disableNative) {
         window.addEventListener('beforeunload', this.onBeforeUnload);
       }
@@ -203,7 +200,7 @@ var NavigationPrompt = function (_React$Component) {
           nextLocation = _state.nextLocation;
 
       action = {
-        'POP': 'goBack',
+        'POP': this.props.useGoBackForPop ? 'goBack' : 'push',
         'PUSH': 'push',
         'REPLACE': 'replace'
       }[action || 'PUSH'];

--- a/es/index.js
+++ b/es/index.js
@@ -213,11 +213,11 @@ var NavigationPrompt = function (_React$Component) {
 
 
       this.state.unblock();
-      this._prevUserAction = 'CONFIRM';
 
       // Special handling for goBack
       if (action === 'goBack') {
         history.goBack();
+        this._prevUserAction = 'CONFIRM';
         // As native history.go(-1) exetues after this method has finished, need to update state asychronously
         // otherwise it will trigger navigateToNextLocation method again
         return window.setTimeout(function () {
@@ -240,6 +240,7 @@ var NavigationPrompt = function (_React$Component) {
         })); // FIXME?  Does history.listen need to be used instead, for async?
       }
       history[action](nextLocation);
+      this._prevUserAction = 'CONFIRM';
 
       this.setState(_extends({}, initState, {
         unblock: this.props.history.block(this.block)

--- a/es/index.js
+++ b/es/index.js
@@ -179,7 +179,6 @@ var NavigationPrompt = function (_React$Component) {
       if (!this.props.disableNative) {
         window.removeEventListener('beforeunload', this.onBeforeUnload);
       }
-      this._isUnmounted = true;
     }
   }, {
     key: 'block',
@@ -222,7 +221,7 @@ var NavigationPrompt = function (_React$Component) {
         // otherwise it will trigger navigateToNextLocation method again
         return window.setTimeout(function () {
           // Skip state update when component has been unmounted in meanwhile. Usually this is what happens.
-          if (!_this2._isUnmounted) {
+          if (_this2._isMounted) {
             _this2.setState(_extends({}, initState, {
               unblock: _this2.props.history.block(_this2.block)
             }));
@@ -239,12 +238,6 @@ var NavigationPrompt = function (_React$Component) {
           unblock: this.props.history.block(this.block)
         })); // FIXME?  Does history.listen need to be used instead, for async?
       }
-      history[action](nextLocation);
-      this._prevUserAction = 'CONFIRM';
-
-      this.setState(_extends({}, initState, {
-        unblock: this.props.history.block(this.block)
-      })); // FIXME?  Does history.listen need to be used instead, for async?
     }
   }, {
     key: 'onCancel',

--- a/es/index.js
+++ b/es/index.js
@@ -132,10 +132,7 @@ var NavigationPrompt = function (_React$Component) {
     var _this = _possibleConstructorReturn(this, (NavigationPrompt.__proto__ || Object.getPrototypeOf(NavigationPrompt)).call(this, props));
 
     _this._prevUserAction = '';
-
-    // This component could be used from inside a page, and therefore could be
-    // mounted/unmounted when the route changes.
-    _this._isMounted = true;
+    _this._isUnmounted = true;
 
     _this.block = _this.block.bind(_this);
     _this.onBeforeUnload = _this.onBeforeUnload.bind(_this);
@@ -150,6 +147,7 @@ var NavigationPrompt = function (_React$Component) {
   _createClass(NavigationPrompt, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
+      this._isUnmounted = false;
       if (!this.props.disableNative) {
         window.addEventListener('beforeunload', this.onBeforeUnload);
       }
@@ -176,6 +174,7 @@ var NavigationPrompt = function (_React$Component) {
       if (!this.props.disableNative) {
         window.removeEventListener('beforeunload', this.onBeforeUnload);
       }
+      this._isUnmounted = true;
     }
   }, {
     key: 'block',

--- a/es/index.js
+++ b/es/index.js
@@ -227,7 +227,7 @@ var NavigationPrompt = function (_React$Component) {
               unblock: _this2.props.history.block(_this2.block)
             }));
           }
-        }, 0);
+        }, 25);
       }
 
       // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-navigation-prompt",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "A replacement component for the react-router `<Prompt/>`. Allows for more flexible dialogs.",
   "scripts": {
     "build": "webpack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-navigation-prompt",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "A replacement component for the react-router `<Prompt/>`. Allows for more flexible dialogs.",
   "scripts": {
     "build": "webpack",
@@ -32,6 +32,7 @@
   "jsnext:main": "es/index.js",
   "main": "es/index.js",
   "module": "es/index.js",
+  "typings": "types/index.d.ts",
   "homepage": "https://github.com/ZacharyRSmith/react-router-navigation-prompt#readme",
   "peerDependencies": {
     "react": ">= 15",

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
             unblock: this.props.history.block(this.block)
           });
         }
-      }, 0);
+      }, 25);
     }
 
     // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ declare type PropsT = {
   renderIfNotActive: bool,
   when: bool | (Location, ?Location) => bool,
   disableNative: bool,
+  allowGoBack: bool,
 };
 declare type StateT = {
   action: ?HistoryAction,
@@ -49,7 +50,6 @@ const initState = {
 class NavigationPrompt extends React.Component<PropsT, StateT> {
   /*:: _prevUserAction: string; */
   /*:: _isMounted: bool; */
-  /*:: _isUnmounted: boolean; */
 
   constructor(props) {
     super(props);
@@ -58,7 +58,6 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
     // See: See https://github.com/ZacharyRSmith/react-router-navigation-prompt/pull/9
     // I don't like making this an instance var,
     this._prevUserAction = '';
-    this._isUnmounted = true;
 
     // This component could be used from inside a page, and therefore could be
     // mounted/unmounted when the route changes.
@@ -74,7 +73,6 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
   }
 
   componentDidMount() {
-    this._isUnmounted = false
     if (!this.props.disableNative) {
       window.addEventListener('beforeunload', this.onBeforeUnload);
     }
@@ -116,7 +114,7 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
   navigateToNextLocation(cb) {
     let {action, nextLocation} = this.state;
     action = {
-      'POP': 'goBack',
+      'POP': this.props.allowGoBack ? 'goBack' : 'push',
       'PUSH': 'push',
       'REPLACE': 'replace'
     }[action || 'PUSH'];

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
   navigateToNextLocation(cb) {
     let {action, nextLocation} = this.state;
     action = {
-      'POP': 'push',
+      'POP': 'goBack',
       'PUSH': 'push',
       'REPLACE': 'replace'
     }[action || 'PUSH'];
@@ -121,6 +121,23 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
     const {history} = this.props;
 
     this.state.unblock();
+
+    if (action === 'goBack') {
+      history.goBack();
+      this._prevUserAction = 'CONFIRM';
+      // This helps when using in goBack
+      window.setTimeout(() => {
+        // There is a change that component has been unmounted after navigation
+        if (this.isMounted) {
+          this.setState({
+            ...initState,
+            unblock: this.props.history.block(this.block)
+          }); // FIXME?  Does history.listen need to be used instead, for async?
+        }
+      }, 0)
+      return
+    }
+
     // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.
     history[action](nextLocation); // could unmount at this point
     this._prevUserAction = 'CONFIRM';

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,6 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
   }
 
   componentDidMount() {
-    this._isUnmounted = false
     if (!this.props.disableNative) {
       window.addEventListener('beforeunload', this.onBeforeUnload);
     }
@@ -98,7 +97,6 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
     if (!this.props.disableNative) {
       window.removeEventListener('beforeunload', this.onBeforeUnload);
     }
-    this._isUnmounted = true
   }
 
   block(nextLocation, action) {

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
   }
 
   componentDidMount() {
+    this._isUnmounted = false
     if (!this.props.disableNative) {
       window.addEventListener('beforeunload', this.onBeforeUnload);
     }
@@ -97,6 +98,7 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
     if (!this.props.disableNative) {
       window.removeEventListener('beforeunload', this.onBeforeUnload);
     }
+    this._isUnmounted = true
   }
 
   block(nextLocation, action) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import * as H from 'history';
+import { RouteComponentProps, Omit } from 'react-router';
+
+declare module 'react-router-navigation-prompt' {
+  export interface ChildData {
+    isActive: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+  }
+
+  export interface NavigationPromptProps extends RouteComponentProps<any> {
+    children: (data: ChildData) => React.ReactNode;
+    when: boolean | ((currentLocation: H.Location, nextLocation?: H.Location) => boolean);
+    afterCancel?: () => void;
+    afterConfirm?: () => void;
+    beforeCancel?: () => void;
+    beforeConfirm?: () => void;
+    renderIfNotActive?: boolean;
+    disableNative?: boolean;
+  }
+
+  interface NavigationPromptState {
+    action?: H.Action;
+    nextLocation?: H.Location;
+    isActive: boolean;
+    unblock: () => void;
+  }
+
+  export class NavigationPrompt extends React.Component<NavigationPromptProps, NavigationPromptState> {
+    _prevUserAction: string;
+    _isMounted: boolean;
+
+    block(nextLocation: H.Location, action: H.Action): boolean;
+    navigateToNextLocation(cb: () => void): void;
+    onCancel(): void;
+    onConfirm(): void;
+    onBeforeUnload(e: any): string
+    when(nextLocation?: H.Location): boolean;
+   }
+}
+
+// This is for the withRouter HOC being used as the default export.
+export default function NavigationPrompt(): React.Component<Omit<NavigationPromptProps, keyof RouteComponentProps<any>>>;


### PR DESCRIPTION
This and attempt to fix #2 and revert of af559d2e1bbd15ae6c50aede8244225fa3272a1a.

Additionally
- it seems that somehow `history.goBack()` executes after `history.block` so I've added the timeout
- due to timeout, component may be trying to use setState after it has been unmounted so I've added simple check

Please do not merge yet