### PR TITLE
Only set state if mounted

### DIFF
--- a/es/index.js
+++ b/es/index.js
@@ -121,6 +121,7 @@ var NavigationPrompt = function (_React$Component) {
   _inherits(NavigationPrompt, _React$Component);
 
   /*:: _prevUserAction: string; */
+  /*:: _isMounted: bool; */
 
   function NavigationPrompt(props) {
     _classCallCheck(this, NavigationPrompt);
@@ -131,6 +132,10 @@ var NavigationPrompt = function (_React$Component) {
     var _this = _possibleConstructorReturn(this, (NavigationPrompt.__proto__ || Object.getPrototypeOf(NavigationPrompt)).call(this, props));
 
     _this._prevUserAction = '';
+
+    // This component could be used from inside a page, and therefore could be
+    // mounted/unmounted when the route changes.
+    _this._isMounted = true;
 
     _this.block = _this.block.bind(_this);
     _this.onBeforeUnload = _this.onBeforeUnload.bind(_this);
@@ -162,6 +167,7 @@ var NavigationPrompt = function (_React$Component) {
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
+      this._isMounted = false;
       if (this._prevUserAction === 'CONFIRM' && typeof this.props.afterConfirm === 'function') {
         this._prevUserAction = '';
         this.props.afterConfirm();
@@ -202,11 +208,14 @@ var NavigationPrompt = function (_React$Component) {
 
       this.state.unblock();
       // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.
-      history[action](nextLocation);
+      history[action](nextLocation); // could unmount at this point
       this._prevUserAction = 'CONFIRM';
-      this.setState(_extends({}, initState, {
-        unblock: this.props.history.block(this.block)
-      })); // FIXME?  Does history.listen need to be used instead, for async?
+      if (this._isMounted) {
+        // Just in case we unmounted on the route change
+        this.setState(_extends({}, initState, {
+          unblock: this.props.history.block(this.block)
+        })); // FIXME?  Does history.listen need to be used instead, for async?
+      }
     }
   }, {
     key: 'onCancel',


### PR DESCRIPTION
I was getting a "setState called from an unmounted component" while trying to use the NavigationPrompt inside of a page. Because of React Fiber's work scheduler (I believe), this only becomes apparent when deferring the `onConfirm` function call, as might be the case when saving data to a server when the confirm button is pressed. I could reproduce it when a confirm button's action was something like `<Button onClick={() => setTimeout(onConfirm, 500);>Confirm</Button`.

Another way would be to adjust where `setState` gets called, but doing things this way preserves the mental association between the action of navigating to a new page and wanting to block history once we're there. The only difference that this pull request does is to make sure that we don't try to block the history (or set state) if the component is no longer mounted.