### PR TITLE
feat: Adding Typescript typings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-navigation-prompt",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "A replacement component for the react-router `<Prompt/>`. Allows for more flexible dialogs.",
   "scripts": {
     "build": "webpack",
@@ -32,6 +32,7 @@
   "jsnext:main": "es/index.js",
   "main": "es/index.js",
   "module": "es/index.js",
+  "typings": "types/index.d.ts",
   "homepage": "https://github.com/ZacharyRSmith/react-router-navigation-prompt#readme",
   "peerDependencies": {
     "react": ">= 15",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import * as H from 'history';
+import { RouteComponentProps, Omit } from 'react-router';
+
+declare module 'react-router-navigation-prompt' {
+  export interface ChildData {
+    isActive: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+  }
+
+  export interface NavigationPromptProps extends RouteComponentProps<any> {
+    children: (data: ChildData) => React.ReactNode;
+    when: boolean | ((currentLocation: H.Location, nextLocation?: H.Location) => boolean);
+    afterCancel?: () => void;
+    afterConfirm?: () => void;
+    beforeCancel?: () => void;
+    beforeConfirm?: () => void;
+    renderIfNotActive?: boolean;
+    disableNative?: boolean;
+  }
+
+  interface NavigationPromptState {
+    action?: H.Action;
+    nextLocation?: H.Location;
+    isActive: boolean;
+    unblock: () => void;
+  }
+
+  export class NavigationPrompt extends React.Component<NavigationPromptProps, NavigationPromptState> {
+    _prevUserAction: string;
+    _isMounted: boolean;
+
+    block(nextLocation: H.Location, action: H.Action): boolean;
+    navigateToNextLocation(cb: () => void): void;
+    onCancel(): void;
+    onConfirm(): void;
+    onBeforeUnload(e: any): string
+    when(nextLocation?: H.Location): boolean;
+   }
+}
+
+// This is for the withRouter HOC being used as the default export.
+export default function NavigationPrompt(): React.Component<Omit<NavigationPromptProps, keyof RouteComponentProps<any>>>;


### PR DESCRIPTION
This PR is to add Typescript typings.

This will allow projects using Typescript to have correct typings when using this component. 
The biggest typing we get from this is to the components props, but this also includes the entire class typings.

Example:
![image](https://user-images.githubusercontent.com/8492971/46025810-61f42480-c0af-11e8-9430-dd012189d80f.png)
