### PR TITLE
Adding allowGoBack option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ import Modal from "./your-own-code";
   - renderIfNotActive: bool,
   - when: bool | (Location, ?Location) => bool,
   - disableNative: bool,
+  - allowGoBack: bool (use _goBack_ method instead of _push_ when navigating back one or more items),
     // Added by react-router:
   - match: Match,
   - history: RouterHistory,

--- a/es/index.js
+++ b/es/index.js
@@ -223,8 +223,8 @@ var NavigationPrompt = function (_React$Component) {
               unblock: _this2.props.history.block(_this2.block)
             }));
           }
-          // Delay of 50ms should be enough to allow navigating back and unmount
-        }, 50);
+          // Delay of 100ms should be enough to allow navigating back and unmount
+        }, 100);
       }
 
       // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.

--- a/es/index.js
+++ b/es/index.js
@@ -223,7 +223,8 @@ var NavigationPrompt = function (_React$Component) {
               unblock: _this2.props.history.block(_this2.block)
             }));
           }
-        }, 25);
+          // Delay of 50ms should be enough to allow navigating back and unmount
+        }, 50);
       }
 
       // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.

--- a/es/index.js
+++ b/es/index.js
@@ -193,12 +193,14 @@ var NavigationPrompt = function (_React$Component) {
   }, {
     key: 'navigateToNextLocation',
     value: function navigateToNextLocation(cb) {
+      var _this2 = this;
+
       var _state = this.state,
           action = _state.action,
           nextLocation = _state.nextLocation;
 
       action = {
-        'POP': 'push',
+        'POP': this.props.allowGoBack ? 'goBack' : 'push',
         'PUSH': 'push',
         'REPLACE': 'replace'
       }[action || 'PUSH'];
@@ -207,6 +209,23 @@ var NavigationPrompt = function (_React$Component) {
 
 
       this.state.unblock();
+
+      // Special handling for goBack
+      if (action === 'goBack') {
+        history.goBack();
+        this._prevUserAction = 'CONFIRM';
+        // As native history.go(-1) exetues after this method has finished, need to update state asychronously
+        // otherwise it will trigger navigateToNextLocation method again
+        return window.setTimeout(function () {
+          // Skip state update when component has been unmounted in meanwhile. Usually this is what happens.
+          if (_this2._isMounted) {
+            _this2.setState(_extends({}, initState, {
+              unblock: _this2.props.history.block(_this2.block)
+            }));
+          }
+        }, 25);
+      }
+
       // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.
       history[action](nextLocation); // could unmount at this point
       this._prevUserAction = 'CONFIRM';
@@ -220,24 +239,24 @@ var NavigationPrompt = function (_React$Component) {
   }, {
     key: 'onCancel',
     value: function onCancel() {
-      var _this2 = this;
+      var _this3 = this;
 
       (this.props.beforeCancel || function (cb) {
         cb();
       })(function () {
-        _this2._prevUserAction = 'CANCEL';
-        _this2.setState(_extends({}, initState));
+        _this3._prevUserAction = 'CANCEL';
+        _this3.setState(_extends({}, initState));
       });
     }
   }, {
     key: 'onConfirm',
     value: function onConfirm() {
-      var _this3 = this;
+      var _this4 = this;
 
       (this.props.beforeConfirm || function (cb) {
         cb();
       })(function () {
-        _this3.navigateToNextLocation(_this3.props.afterConfirm);
+        _this4.navigateToNextLocation(_this4.props.afterConfirm);
       });
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -137,8 +137,8 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
             unblock: this.props.history.block(this.block)
           });
         }
-      // Delay of 50ms should be enough to allow navigating back and unmount
-      }, 50);
+      // Delay of 100ms should be enough to allow navigating back and unmount
+      }, 100);
     }
 
     // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
         }
       });
       history.goBack();
-      return
+      return;
     }
 
     // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.

--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,8 @@ class NavigationPrompt extends React.Component<PropsT, StateT> {
             unblock: this.props.history.block(this.block)
           });
         }
-      }, 25);
+      // Delay of 50ms should be enough to allow navigating back and unmount
+      }, 50);
     }
 
     // $FlowFixMe history.replace()'s type expects LocationShape even though it works with Location.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,6 +18,7 @@ declare module 'react-router-navigation-prompt' {
     beforeConfirm?: () => void;
     renderIfNotActive?: boolean;
     disableNative?: boolean;
+    allowGoBack?: boolean;
   }
 
   interface NavigationPromptState {


### PR DESCRIPTION
This PR superseeds #30 (where I'v messed my branch) and also fixes #2.

It adds a _allowGoBack_ option, which when set to true allows for more native experience when user pushes _Back_ button.

In normal state of react-router-navigation-prompt when user click _Back_ button, prompt pops up. Then when he/ she choose _Confirm_ action and new location is pushed into browser history.

When _allowGoBack_ option is set to true, browser performs a _goBack_ method instead, going back in browsers history by one entry.

This is especially helpful in mobile apps (Progressive web apps, contained in webview or cordova hybrid apps) when back button is also used to exit an app.

Unlike in desktop browser, there is no feature to choose the point in browsers history where to go back, as UI consists only of hardware back button or soft key.