### PR TITLE
Fix default export type for future Typescript versions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,4 +40,4 @@ interface NavigationPromptWithRouter extends React.Component<NavigationPromptPro
 }
 
 // This is for the withRouter HOC being used as the default export.
-export default function NavigationPrompt(): React.Component<Omit<NavigationPromptProps, keyof RouteComponentProps<any>>>;
+export default class NavigationPrompt extends React.Component<Omit<NavigationPromptProps, keyof RouteComponentProps<any>>> {};


### PR DESCRIPTION
This change fixes the following type error for Typescript version `3.2.0` and up.

![screenshot 2018-11-28 at 09 55 48](https://user-images.githubusercontent.com/7240988/49140488-ad67c080-f2f4-11e8-8fa7-c594995d59f9.png)

Any feedback is appreciated.