### PR TITLE
fix: Remove problematic semicolon

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,4 +40,4 @@ interface NavigationPromptWithRouter extends React.Component<NavigationPromptPro
 }
 
 // This is for the withRouter HOC being used as the default export.
-export default class NavigationPrompt extends React.Component<Omit<NavigationPromptProps, keyof RouteComponentProps<any>>> {};
+export default class NavigationPrompt extends React.Component<Omit<NavigationPromptProps, keyof RouteComponentProps<any>>> {}


### PR DESCRIPTION
I shouldn't edit files in the web editor in a hurry. Because of that I added an unnecessary semicolon at the end that actually causes the Typescript compiler to complain.

![error](https://user-images.githubusercontent.com/7240988/49318725-f9378700-f4f9-11e8-820b-c755611eb125.jpg)

Sorry if my haste caused any issues for people :sob: 