### PR TITLE
Add TypeScript definition check command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prepare": "npm run lint; npm run flow; npm run build",
     "test": "concurrently -k \"npm run test-server\" \"npm run testcafe\"",
     "test-server": "webpack-dev-server --config ./test/webpack.config.js",
-    "testcafe": "testcafe chrome test/index.js"
+    "testcafe": "testcafe chrome test/index.js",
+    "typescript": "tsc --noEmit ./types/index.d.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've added a command in the `package.json` it'll only check the definition file for basic things but it would've caught my earlier mistake.

Another option might be to look into https://github.com/Microsoft/TypeScript/wiki/Type-Checking-JavaScript-Files 

There's also tools that can generate the type definition file from JSDoc comments.