### PR TITLE
Add callback parameters to before* properties

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,8 +14,8 @@ export interface NavigationPromptProps extends RouteComponentProps<any> {
   afterCancel?: () => void;
   afterConfirm?: () => void;
   allowGoBack?: boolean;
-  beforeCancel?: () => void;
-  beforeConfirm?: () => void;
+  beforeCancel?: (callback: Function) => void;
+  beforeConfirm?: (callback: Function) => void;
   renderIfNotActive?: boolean;
   disableNative?: boolean;
 }


### PR DESCRIPTION
Adds proper typing to the `beforeConfirm` and `beforeCancel` properties.

Fixes #51 